### PR TITLE
Allow disable time protection and adjust current time

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ module.exports = function(secret, options = {}) {
     options.identifier = options.identifier || 'HMAC';
     options.header = options.header || 'authentication';
     options.maxInterval = options.maxInterval || 60 * 5;
-    options.timeProtection = options.timeProtection !== undefined ? options.timeProtection : true;
     options.minInterval = options.minInterval || 0;
 
     const error = validateArguments(secret, options);
@@ -38,7 +37,7 @@ module.exports = function(secret, options = {}) {
 
         // is the unix timestamp difference to current timestamp larger than maxInterval
         const timeDiff = Math.floor(Date.now() / 1000) - Math.floor(parseInt(unixMatch[1]) / 1000);
-        if (options.timeProtection && (timeDiff > options.maxInterval || timeDiff < options.minInterval)) {
+        if (timeDiff > options.maxInterval || timeDiff < options.minInterval) {
             return next(new HMACAuthError('Time difference between generated and requested time is too great'));
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ module.exports = function(secret, options = {}) {
     options.identifier = options.identifier || 'HMAC';
     options.header = options.header || 'authentication';
     options.maxInterval = options.maxInterval || 60 * 5;
+    options.timeProtection = options.timeProtection || true;
 
     const error = validateArguments(secret, options);
     if (error) {
@@ -36,7 +37,7 @@ module.exports = function(secret, options = {}) {
 
         // is the unix timestamp difference to current timestamp larger than maxInterval
         const timeDiff = Math.floor(Date.now() / 1000) - Math.floor(parseInt(unixMatch[1]) / 1000);
-        if (timeDiff > options.maxInterval || timeDiff < 0) {
+        if (options.timeProtection && (timeDiff > options.maxInterval || timeDiff < 0)) {
             return next(new HMACAuthError('Time difference between generated and requested time is too great'));
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,8 @@ module.exports = function(secret, options = {}) {
     options.identifier = options.identifier || 'HMAC';
     options.header = options.header || 'authentication';
     options.maxInterval = options.maxInterval || 60 * 5;
-    options.timeProtection = options.timeProtection || true;
-    options.timeAdjust = options.timeAdjust || 0;
+    options.timeProtection = options.timeProtection !== undefined ? options.timeProtection : true;
+    options.minInterval = options.minInterval || 0;
 
     const error = validateArguments(secret, options);
     if (error) {
@@ -36,9 +36,11 @@ module.exports = function(secret, options = {}) {
             return next(new HMACAuthError('Unix timestamp was not present in header'));
         }
 
+        console.log(options.timeProtection);
+
         // is the unix timestamp difference to current timestamp larger than maxInterval
         const timeDiff = Math.floor(Date.now() / 1000) - Math.floor(parseInt(unixMatch[1]) / 1000);
-        if (options.timeProtection && (timeDiff > options.maxInterval || timeDiff < options.timeAdjust)) {
+        if (options.timeProtection && (timeDiff > options.maxInterval || timeDiff < options.minInterval)) {
             return next(new HMACAuthError('Time difference between generated and requested time is too great'));
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,8 +36,6 @@ module.exports = function(secret, options = {}) {
             return next(new HMACAuthError('Unix timestamp was not present in header'));
         }
 
-        console.log(options.timeProtection);
-
         // is the unix timestamp difference to current timestamp larger than maxInterval
         const timeDiff = Math.floor(Date.now() / 1000) - Math.floor(parseInt(unixMatch[1]) / 1000);
         if (options.timeProtection && (timeDiff > options.maxInterval || timeDiff < options.minInterval)) {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ module.exports = function(secret, options = {}) {
     options.header = options.header || 'authentication';
     options.maxInterval = options.maxInterval || 60 * 5;
     options.timeProtection = options.timeProtection || true;
+    options.timeAdjust = options.timeAdjust || 0;
 
     const error = validateArguments(secret, options);
     if (error) {
@@ -37,7 +38,7 @@ module.exports = function(secret, options = {}) {
 
         // is the unix timestamp difference to current timestamp larger than maxInterval
         const timeDiff = Math.floor(Date.now() / 1000) - Math.floor(parseInt(unixMatch[1]) / 1000);
-        if (options.timeProtection && (timeDiff > options.maxInterval || timeDiff < 0)) {
+        if (options.timeProtection && (timeDiff > options.maxInterval || timeDiff < options.timeAdjust)) {
             return next(new HMACAuthError('Time difference between generated and requested time is too great'));
         }
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -209,19 +209,6 @@ describe('hmac', () => {
         global.Date.now = originalDateNow;
     });
 
-    test('passes if time protection is disabled', () => {
-        const originalDateNow = Date.now.bind(global.Date);
-        global.Date.now = () => 1573508732400;
-
-        const middleware = hmac('secret', { timeProtection: false });
-
-        middleware(mockedRequest(), undefined, spies.next);
-
-        expect(spies.next).toHaveBeenLastCalledWith();
-
-        global.Date.now = originalDateNow;
-    });
-
     test('fails if missing hmac digest', () => {
         const originalDateNow = Date.now.bind(global.Date);
         global.Date.now = () => 1573504737300;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -196,6 +196,32 @@ describe('hmac', () => {
         global.Date.now = originalDateNow;
     });
 
+    test('passes if time before timestamp in hmac but minInterval is configured', () => {
+        const originalDateNow = Date.now.bind(global.Date);
+        global.Date.now = () => 1573504736300;
+
+        const middleware = hmac('secret', { minInterval: -1 });
+
+        middleware(mockedRequest(), undefined, spies.next);
+
+        expect(spies.next).toHaveBeenLastCalledWith();
+
+        global.Date.now = originalDateNow;
+    });
+
+    test('passes if time protection is disabled', () => {
+        const originalDateNow = Date.now.bind(global.Date);
+        global.Date.now = () => 1573508732400;
+
+        const middleware = hmac('secret', { timeProtection: false });
+
+        middleware(mockedRequest(), undefined, spies.next);
+
+        expect(spies.next).toHaveBeenLastCalledWith();
+
+        global.Date.now = originalDateNow;
+    });
+
     test('fails if missing hmac digest', () => {
         const originalDateNow = Date.now.bind(global.Date);
         global.Date.now = () => 1573504737300;


### PR DESCRIPTION
- Add option to disable time protection if it is required for debug or test purposes.
- Add option to set time min interval to accept clients that time isn't well synchronized.