### PR TITLE
minInterval option in documentation is ambiguous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.0] - 2020-08-12
+### Changed
+- **Breaking** Inversed `timeDiff` value in comparison against `minInterval` option so option parameters are consistent.
+
 ## [5.0.1] - 2020-08-12
 ### Changed
 - Updated `parseInt` call to pass `radix` parameter of `10`

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,5 +1,11 @@
 # Migration Guide
 
+## Migrating to 6.0.0 [#15](https://github.com/connorjburton/hmac-auth-express/issues/15)
+
+Prior to this version, the documentation ambiguously stated that the `options.minInterval` function parameter was to be provided as an integer, missing out the requirement that this should also be negative. `6.0.0` now expects a positive integer value to be provided for the `minInterval` property and will throw a `TypeError` if a negative value is provided. This value is still optional and can be omitted if not required.
+
+
+
 ## Migrating from 3.x.x to 4.0.0 [#2](https://github.com/connorjburton/hmac-auth-express/issues/2)
 
 Previously, the documentation incorrectly stated the header and HMAC digest expected a UNIX timestamp, this however was incorrect as the middleware expected a `UNIX timestamp / 1000`. `4.0.0` now expects you to actually pass a UNIX timestamp.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmac-auth-express",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ module.exports = function(secret, options = {}) {
 
         // is the unix timestamp difference to current timestamp larger than maxInterval
         const timeDiff = Math.floor(Date.now() / 1000) - Math.floor(parseInt(unixMatch[1], 10) / 1000);
-        if (timeDiff > options.maxInterval || timeDiff < options.minInterval) {
+        if (timeDiff > options.maxInterval || (timeDiff * -1) > options.minInterval) {
             return next(new HMACAuthError('Time difference between generated and requested time is too great'));
         }
 

--- a/src/validateArguments.js
+++ b/src/validateArguments.js
@@ -20,4 +20,8 @@ module.exports = function(secret, options) {
     if (!options.maxInterval || typeof options.maxInterval !== 'number' || Number.isNaN(options.maxInterval)) {
         return new TypeError(`Invalid value provided for property options.maxInterval. Expected number but got '${options.maxInterval}' (type: ${typeof options.maxInterval})`);
     }
+
+    if (typeof options.minInterval !== 'number' || Number.isNaN(options.minInterval) || options.minInterval < 0) {
+        return new TypeError(`Invalid value provided for optional property options.minInterval. Expected positive number but got '${options.minInterval}' (type: ${typeof options.minInterval})`);
+    }
 }

--- a/src/validateArguments.js
+++ b/src/validateArguments.js
@@ -22,6 +22,6 @@ module.exports = function(secret, options) {
     }
 
     if (typeof options.minInterval !== 'number' || Number.isNaN(options.minInterval) || options.minInterval < 0) {
-        return new TypeError(`Invalid value provided for optional property options.minInterval. Expected positive number but got '${options.minInterval}' (type: ${typeof options.minInterval})`);
+        return new TypeError(`Invalid value provided for optional property options.minInterval. Expected positive integer but got '${options.minInterval}' (type: ${typeof options.minInterval})`);
     }
 }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -213,7 +213,7 @@ describe('hmac', () => {
         const originalDateNow = Date.now.bind(global.Date);
         global.Date.now = () => 1573504736300;
 
-        const middleware = hmac('secret', { minInterval: -1 });
+        const middleware = hmac('secret', { minInterval: 1 });
 
         middleware(mockedRequest(), undefined, spies.next);
 
@@ -256,5 +256,13 @@ describe('hmac', () => {
 
     test('passing incorrect maxInterval throws an error', () => {
         expect(() => hmac('secret', { maxInterval: 'abc' })).toThrowError(new TypeError(`Invalid value provided for property options.maxInterval. Expected number but got 'abc' (type: string)`));
+    });
+
+    test('passing incorrect minInterval throws an error', () => {
+        expect(() => hmac('secret', { minInterval: 'abc' })).toThrowError(new TypeError(`Invalid value provided for optional property options.minInterval. Expected positive number but got 'abc' (type: string)`));
+    });
+
+    test('passing negative number for minInterval throws an error', () => {
+        expect(() => hmac('secret', { minInterval: -1 })).toThrowError(new TypeError(`Invalid value provided for optional property options.minInterval. Expected positive number but got '-1' (type: number)`));
     });
 });


### PR DESCRIPTION
The `options.minInterval` function parameter is described as requiring an integer value but doesn't specify that this should be a negative value. 

I've reworked the `minInterval` functionality to accept positive integers only so the input is consistent with the rest of the parameters. There's also a new TypeError if a provided `minInterval` value is not a number or is negative.