### PR TITLE
fix: specify node version in engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
         "auth",
         "hmac"
     ],
+    "engines": {
+        "node": ">=6.6.0"
+    },
     "main": "./dist/index.js",
     "typings": "./dist",
     "scripts": {


### PR DESCRIPTION
Fixes #46 